### PR TITLE
RedPenのダウンロード方法を改善した

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Re:VIEWビルド + RedPenでのテスト + Travis CIによる継続的インテグレーション環境を構築できるリポジトリです。
 Node.jsとRuby + Bundlerのインストールが必要です。
 
+## 依存しているもの
+
+RedPenのダウンロードで[jq](https://stedolan.github.io/jq/)に依存しています。
+[Download jq](https://stedolan.github.io/jq/download/)を読んで、ダウンロードをお願いします。
+
 ## 準備
 
 ```shell

--- a/bin/setup-redpen.sh
+++ b/bin/setup-redpen.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-REDPEN_URL=https://github.com/recruit-tech/redpen/releases/download
+URL=https://api.github.com/repos/redpen-cc/redpen/releases/latest
+OUTPUT_TEMP_FILE=redpen.json
 
-curl -OL $REDPEN_URL/redpen-$1/redpen-$1.tar.gz
-tar xvf redpen-$1.tar.gz
-rm redpen-$1.tar.gz
+curl -s $URL > $OUTPUT_TEMP_FILE
+
+FILE_NAME=`cat $OUTPUT_TEMP_FILE | jq -r ".assets[] | select (.name | test(\"${spruce_type}\")) | .name"`
+DOWNLOAD_URL=`cat $OUTPUT_TEMP_FILE | jq -r ".assets[] | select (.name | test(\"${spruce_type}\")) | .browser_download_url"`
+
+curl -OL $DOWNLOAD_URL
+tar xvf $FILE_NAME
+rm $FILE_NAME $OUTPUT_TEMP_FILE

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Re:VIEW boilerplate",
   "scripts": {
     "test": "gulp redpen",
-    "setup": "bundle install --path vendor/bundle && npm install && ./bin/setup-redpen.sh 1.6.2",
+    "setup": "bundle install --path vendor/bundle && npm install && ./bin/setup-redpen.sh",
     "deploy": "gulp deploy",
     "clean": "gulp clean",
     "pdf": "gulp pdf",


### PR DESCRIPTION
GitHub API、curl、それとjqを使って最新版をダウンロードするようにした